### PR TITLE
Add Replicate demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # tencent-ailab / IP-Adapter
 
+[![Try a demo on Replicate](https://replicate.com/lucataco/ip_adapter-face-inpaint/badge)](https://replicate.com/lucataco/ip_adapter-face-inpaint)
+
 This is an implementation of a face-inpaint method [tencent-ailab / IP-Adapter](https://github.com/tencent-ailab/IP-Adapter) as a Cog model. [Cog packages machine learning models as standard containers.](https://github.com/replicate/cog)
 
 First, download the pre-trained weights:


### PR DESCRIPTION
This PR adds a badge with a link to your model on Replicate, making it easier for users to try it out. 

Feel free to close if you don't want this, but many model creators have found it helpful.